### PR TITLE
Add 301 Moved Permanently --fix support

### DIFF
--- a/src/no-dead-link.js
+++ b/src/no-dead-link.js
@@ -24,7 +24,7 @@ function isRelative(uri) {
 /**
  * Checks if a given URI is alive or not.
  * @param {string} uri
- * @return {{ ok: boolean, redirect: string, message: string }}
+ * @return {{ ok: boolean, redirect?: string, message: string }}
  */
 async function isAlive(uri) {
   try {

--- a/src/no-dead-link.js
+++ b/src/no-dead-link.js
@@ -24,7 +24,7 @@ function isRelative(uri) {
 /**
  * Checks if a given URI is alive or not.
  * @param {string} uri
- * @return {{ ok: bool, message: string }}
+ * @return {{ ok: boolean, redirect: string, message: string }}
  */
 async function isAlive(uri) {
   try {
@@ -34,9 +34,22 @@ async function isAlive(uri) {
       // to avoid the zlib's "unexpected end of file" error
       // https://github.com/request/request/issues/2045
       compress: false,
+      // manual redirect
+      redirect: 'manual'
     };
     const res = await fetch(uri, opts);
 
+    if (res.status === 301) {
+      const finalRes = await fetch(uri, {
+        method: 'HEAD',
+        compress: false
+      });
+      return {
+        ok: finalRes.ok,
+        redirect: finalRes.url,
+        message: `${res.status} ${res.statusText}`,
+      };
+    }
     return {
       ok: res.ok,
       message: `${res.status} ${res.statusText}`,
@@ -55,6 +68,7 @@ function reporter(context, options = {}) {
     getSource,
     report,
     RuleError,
+    fixer
   } = context;
   const helper = new RuleHelper(context);
   const opts = Object.assign({}, DEFAULT_OPTIONS, options);
@@ -85,11 +99,18 @@ function reporter(context, options = {}) {
       uri = URL.resolve(opts.baseURI, uri);
     }
 
-    const { ok, message: msg } = await isAlive(uri);
+    const { ok, redirect, message: msg } = await isAlive(uri);
 
     if (!ok) {
       const message = `${uri} is dead. (${msg})`;
-      report(node, new RuleError(message, { index }));
+      report(node, new RuleError(message, {index}));
+    } else if (redirect) {
+      const message = `${uri} is redirected. (${msg})`;
+      const fix = fixer.replaceTextRange([index, index + uri.length], redirect);
+      report(node, new RuleError(message, {
+        fix,
+        index
+      }));
     }
   };
 
@@ -125,11 +146,13 @@ function reporter(context, options = {}) {
       if (helper.isChildNode(node, [Syntax.BlockQuote])) {
         return;
       }
-
+      // [text](http://example.com)
+      //       ^
+      const index = node.raw.indexOf(node.url) || 0;
       URIs.push({
         node,
         uri: node.url,
-        index: 0,
+        index,
       });
     },
 

--- a/src/no-dead-link.js
+++ b/src/no-dead-link.js
@@ -10,7 +10,7 @@ const DEFAULT_OPTIONS = {
 
 // http://stackoverflow.com/a/3809435/951517
 // eslint-disable-next-line max-len
-const URI_REGEXP = /(https?:)?\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/g;
+const URI_REGEXP = /(https?:)?\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_+.~#?&//=]*)/g;
 
 /**
  * Returns `true` if a given URI is relative.
@@ -35,14 +35,14 @@ async function isAlive(uri) {
       // https://github.com/request/request/issues/2045
       compress: false,
       // manual redirect
-      redirect: 'manual'
+      redirect: 'manual',
     };
     const res = await fetch(uri, opts);
 
     if (res.status === 301) {
       const finalRes = await fetch(uri, {
         method: 'HEAD',
-        compress: false
+        compress: false,
       });
       return {
         ok: finalRes.ok,
@@ -68,7 +68,7 @@ function reporter(context, options = {}) {
     getSource,
     report,
     RuleError,
-    fixer
+    fixer,
   } = context;
   const helper = new RuleHelper(context);
   const opts = Object.assign({}, DEFAULT_OPTIONS, options);
@@ -103,13 +103,13 @@ function reporter(context, options = {}) {
 
     if (!ok) {
       const message = `${uri} is dead. (${msg})`;
-      report(node, new RuleError(message, {index}));
+      report(node, new RuleError(message, { index }));
     } else if (redirect) {
       const message = `${uri} is redirected. (${msg})`;
       const fix = fixer.replaceTextRange([index, index + uri.length], redirect);
       report(node, new RuleError(message, {
         fix,
-        index
+        index,
       }));
     }
   };

--- a/test/no-dead-link.js
+++ b/test/no-dead-link.js
@@ -40,8 +40,8 @@ tester.run('no-dead-link', rule, {
           message: 'http://httpstat.us/301 is redirected. (301 Moved Permanently)',
           line: 1,
           column: 18,
-        }
-      ]
+        },
+      ],
     },
     {
       text: 'should treat 301 [link](http://httpstat.us/301)',
@@ -51,8 +51,8 @@ tester.run('no-dead-link', rule, {
           message: 'http://httpstat.us/301 is redirected. (301 Moved Permanently)',
           line: 1,
           column: 25,
-        }
-      ]
+        },
+      ],
     },
     {
       text: 'should treat 404 Not Found as dead: http://httpstat.us/404',

--- a/test/no-dead-link.js
+++ b/test/no-dead-link.js
@@ -9,7 +9,6 @@ tester.run('no-dead-link', rule, {
     'should be able to check a link in Markdown: [example](https://example.com/)',
     'should be able to check a URL in Markdown: https://example.com/',
     'should treat 200 OK as alive: http://httpstat.us/200',
-    'should treat 301 Moved Permanently as alive: http://httpstat.us/301',
     {
       text: 'should be able to check a URL in a plain text: https://example.com/',
       ext: '.txt',
@@ -34,10 +33,32 @@ tester.run('no-dead-link', rule, {
   ],
   invalid: [
     {
-      text: 'should treat 404 Not Found as dead: https://example.com/404.html',
+      text: 'should treat 301 http://httpstat.us/301',
+      output: 'should treat 301 http://httpstat.us/',
       errors: [
         {
-          message: 'https://example.com/404.html is dead. (404 Not Found)',
+          message: 'http://httpstat.us/301 is redirected. (301 Moved Permanently)',
+          line: 1,
+          column: 18,
+        }
+      ]
+    },
+    {
+      text: 'should treat 301 [link](http://httpstat.us/301)',
+      output: 'should treat 301 [link](http://httpstat.us/)',
+      errors: [
+        {
+          message: 'http://httpstat.us/301 is redirected. (301 Moved Permanently)',
+          line: 1,
+          column: 25,
+        }
+      ]
+    },
+    {
+      text: 'should treat 404 Not Found as dead: http://httpstat.us/404',
+      errors: [
+        {
+          message: 'http://httpstat.us/404 is dead. (404 Not Found)',
           line: 1,
           column: 37,
         },
@@ -54,11 +75,11 @@ tester.run('no-dead-link', rule, {
       ],
     },
     {
-      text: 'should locate the exact index of a URL in a plain text: https://example.com/404.html',
+      text: 'should locate the exact index of a URL in a plain text: http://httpstat.us/404',
       ext: '.txt',
       errors: [
         {
-          message: 'https://example.com/404.html is dead. (404 Not Found)',
+          message: 'http://httpstat.us/404 is dead. (404 Not Found)',
           line: 1,
           column: 57,
         },


### PR DESCRIPTION
Hi, I've added `--fix` support for  301 Moved Permanently

If the url is redirect as 301, this rule should fix(resolve) the url.

/cc @nodaguti 