### PR TITLE
Add HTTP GET fallback

### DIFF
--- a/src/no-dead-link.js
+++ b/src/no-dead-link.js
@@ -24,12 +24,13 @@ function isRelative(uri) {
 /**
  * Checks if a given URI is alive or not.
  * @param {string} uri
+ * @param {string} method
  * @return {{ ok: boolean, redirect?: string, message: string }}
  */
-async function isAlive(uri) {
+async function isAlive(uri, method = 'HEAD') {
   try {
     const opts = {
-      method: 'HEAD',
+      method,
       // Disable gzip compression in Node.js
       // to avoid the zlib's "unexpected end of file" error
       // https://github.com/request/request/issues/2045
@@ -99,7 +100,8 @@ function reporter(context, options = {}) {
       uri = URL.resolve(opts.baseURI, uri);
     }
 
-    const { ok, redirect, message: msg } = await isAlive(uri);
+    const result = await isAlive(uri);
+    const { ok, redirect, message: msg } = result.ok ? result : await isAlive(uri, 'GET');
 
     if (!ok) {
       const message = `${uri} is dead. (${msg})`;


### PR DESCRIPTION
Some servers support only HTTP GET access but not HEAD, for example, [http://nlftp.mlit.go.jp/](http://nlftp.mlit.go.jp/).
This PR add checking with HTTP GET after checking with HEAD failed.