### PR TITLE
Ignore HTML5 place holder link.

### DIFF
--- a/src/no-dead-link.js
+++ b/src/no-dead-link.js
@@ -146,6 +146,10 @@ function reporter(context, options = {}) {
       if (helper.isChildNode(node, [Syntax.BlockQuote])) {
         return;
       }
+      // Ignore HTML5 place holder link. Ex) <a>Placeholder Link</a>
+      if (typeof node.url === "undefined") {
+        return;
+      }      
       // [text](http://example.com)
       //       ^
       const index = node.raw.indexOf(node.url) || 0;


### PR DESCRIPTION
When applying textlint-rule-no-dead-link to HTML, an error occurred.

```console
✖ Stack trace
TypeError: Parameter "url" must be a string, not undefined
    at Url.parse (url.js: 102: 11)
    at Object.urlParse [as parse] (url.js: 96: 5)
    at isRelative
(/usr/local/lib/node_modules/textlint-rule-no-dead-link/lib/no-dead-link
.js:83:24)
    at
/usr/local/lib/node_modules/textlint-rule-no-dead-link/lib/no-dead-link.
js: 107: 11
    at Generator.next (<anonymous>)
```

When using the HTML5 replaceholder link, url is undefined.
Links without URLs are correct as HTML,  so i think should ignore to
them if url is undefined.